### PR TITLE
enable local installation of storm

### DIFF
--- a/src/storm/values.yaml
+++ b/src/storm/values.yaml
@@ -91,11 +91,11 @@ persistence:
     # existingClaim:
 
 zookeeper:
-  enabled: true
+  enabled: false
   replicaCount: 1
   # # if using an external zookeeper, you need to set the server names below
-  # servers: 
-  #  - "example.external.zookeeper1"
+  servers: 
+   - "zookeeper.default.svc.cluster.local"
   #  - "example.external.zookeeper2"
   #  - "example.external.zookeeper3"
   # # external server port


### PR DESCRIPTION
**_Original request_**

```
Hello,
I cannot figure out how to deploy the storm cluster with an external zookeeper…
Trying something like this:
helm install storm gresearch/storm  
--set zookeeper.enabled=false  
--set zookeeper.servers[0]=zookeeper.default.svc.cluster.local
And that’s the output:
Error: template: storm/templates/nimbus-statefulset.yaml:103:12: executing "storm/templates/nimbus-statefulset.yaml" at <include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global)>: error calling include: template: no template "common.storage.class" associated with template "gotpl"
Trying to modify the default values of the chart's yaml and i achieve the same results. Where am i wrong?
My zookeeper is in the same kubernetes cluster (Rancher) deployed via bitnami helm chart and kafka can reach it. maybe the fact that usually "onpremise" zookeeper uses a quorum can be a problem?
Can you provide an example of how to set zookeeper container as disabled and external (but in same kubernetes cluster) zookeeper connection?
Regards
```

How to test / reproduce the issue:
```
kind create cluster
helm install zookeeper bitnami/zookeeper --wait
(checkout this branch)
helm install -f values.yaml storm-local .
````
You should get this message, same as original one:
```
Error: INSTALLATION FAILED: template: storm/templates/nimbus-statefulset.yaml:103:12: executing "storm/templates/nimbus-statefulset.yaml" at <include "common.storage.class" (dict "persistence" .Values.persistence "global" .Values.global)>: error calling include: template: no template "common.storage.class" associated with template "gotpl"
```

Current status: I've managed to isolate issue and currently I'm playing with conditions in the file `charts/src/storm/templates/nimbus-statefulset.yaml` and `charts/src/storm/values.yaml`.

One way to solve this issue is to add 
```
{{- define "common.storage.class" -}}
{{- end }}
```
anywhere in `charts/src/storm/templates/_helpers.tpl` file.

But there must be a better way to handle this and break some functionality, I think the bug is on our site after line [#70](https://github.com/ljubon/charts/blob/c18f6278a515e0089b3581bda440a0d295a32e67/src/storm/templates/nimbus-statefulset.yaml#L70) somewhere in those conditions which i couldn't solve by now...

Any help/feedback would be welcomed :)

Links that helped me
- https://github.com/bitnami/charts/commit/aaed4ae90a54e39050476da3c1f957c3c7e67579
- https://helm.sh/docs/chart_template_guide/control_structures/#ifelse