### PR TITLE
add fasttrackml chart support

### DIFF
--- a/.github/workflows/scripts/config.json
+++ b/.github/workflows/scripts/config.json
@@ -1,6 +1,26 @@
 {
   "G-Research": [
     {
+      "name": "fasttrackml",
+      "refs": [
+        {
+          "ref": "^refs/tags/v\\d+\\.\\d+\\.\\d+",
+          "type": "regex"
+        },
+        {
+          "type": "branch",
+          "ref": "master"
+        }
+      ],
+      "helm_charts": [
+        {
+          "name": "fasttrackml",
+          "source": "chart",
+          "destination": "fasttrackml"
+        }
+      ]
+    },
+    {
       "name": "charts",
       "refs": [
         {


### PR DESCRIPTION
As part of https://github.com/G-Research/oss-portfolio-maturity/issues/350 goal of this PR is to support publishing `fasttrackml` chart to the chart repo following the same rules as publishing `fasttracml` release (e.g push tag vX.Y.Z)